### PR TITLE
Use more recent upload-artifact and checkout actions for the GitHub runner.

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/build_linux_arm.yml
+++ b/.github/workflows/build_linux_arm.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -153,7 +153,7 @@ jobs:
           cp -rf ${{ github.workspace }}/README.md ${{ github.workspace }}/sample/addons/iree-gd/README.md
 
       - name: Export libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: iree-gd-${{ matrix.float_precision }}-${{ matrix.target }}-${{ matrix.arch }}-${{ matrix.build_type }}
           path: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Merge artifacts
         uses: actions/upload-artifact/merge@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup clang-format
         shell: bash
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download iree-gd
         uses: dawidd6/action-download-artifact@v3


### PR DESCRIPTION
This get rid of most of the [actions warnings](https://github.com/iree-gd/iree.gd/actions/runs/11652267297):

![SCR-20241103-orcs](https://github.com/user-attachments/assets/dcab182b-e8e4-4768-81bf-9b694c85a946)
